### PR TITLE
chore(project): include source code in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 example
 assets
 !dist/*
-lib
 rollup.config.js


### PR DESCRIPTION
This allows npm package users to subclass Linting instead of forcing to use a whole module.