### PR TITLE
feat(i18n): Use "translate" service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to [bpmn-js-bpmnlint](https://github.com/bpmn-io/bpmn-js-bpm
 ## Unreleased
 
 ___Note:__ Yet to be released changes appear here._
+* `FEAT`: add translation of reports
 
 ## 0.13.1
 

--- a/lib/Linting.js
+++ b/lib/Linting.js
@@ -45,13 +45,15 @@ export default function Linting(
     config,
     elementRegistry,
     eventBus,
-    overlays
+    overlays,
+    translate
 ) {
   this._bpmnjs = bpmnjs;
   this._canvas = canvas;
   this._elementRegistry = elementRegistry;
   this._eventBus = eventBus;
   this._overlays = overlays;
+  this._translate = translate;
 
   this._issues = {};
 
@@ -348,7 +350,7 @@ Linting.prototype._addWarnings = function($ul, warnings) {
 Linting.prototype._addEntry = function($ul, state, entry) {
 
   var rule = entry.rule,
-      message = entry.message;
+      message = this._translate(entry.message);
 
   var icon = stateToIcon[state];
 
@@ -384,7 +386,7 @@ Linting.prototype._setButtonState = function(state, errors, warnings) {
 
   var icon = stateToIcon[state];
 
-  var html = icon + '<span>' + errors + ' Errors, ' + warnings + ' Warnings</span>';
+  var html = icon + '<span>' + this._translate('{errors} Errors, {warnings} Warnings', { errors: errors.toString(), warnings: warnings.toString() }) + '</span>';
 
   [
     'error',
@@ -433,7 +435,7 @@ Linting.prototype._createButton = function() {
   var self = this;
 
   this._button = domify(
-    '<button class="bjsl-button bjsl-button-inactive" title="Toggle linting"></button>'
+    '<button class="bjsl-button bjsl-button-inactive" title="' + this._translate('Toggle linting') + '"></button>'
   );
 
   this._button.addEventListener('click', function() {
@@ -457,5 +459,6 @@ Linting.$inject = [
   'config.linting',
   'elementRegistry',
   'eventBus',
-  'overlays'
+  'overlays',
+  'translate'
 ];

--- a/test/spec/LintingSpec.js
+++ b/test/spec/LintingSpec.js
@@ -259,6 +259,7 @@ describe('linting', function() {
 
 });
 
+
 describe('i18n', function() {
 
   it('should translate lint issues text', function(done) {
@@ -331,6 +332,7 @@ describe('i18n', function() {
       });
 
     });
+
   });
 
 });


### PR DESCRIPTION
Translate all the UI messages returned from rules and in generated UI by linter.

A side note: seems like Linting.js file was previously committed with CRLF.
I have to set "autocrlf = false" in my git config AND commit file with CRLF to get github show only actually changed lines instead of show every single line as changed.
