### PR TITLE
feat(linting): Display root element warnings

### DIFF
--- a/lib/Linting.js
+++ b/lib/Linting.js
@@ -340,7 +340,7 @@ Linting.prototype._createElementIssues = function(elementId, elementIssues) {
   var errors = issuesByType.error,
       warnings = issuesByType.warn,
       childErrors = issuesByType.childerror,
-      childWarnings = issuesByType.childwarning;
+      childWarnings = issuesByType.childwarn;
 
   if (!errors && !warnings && !childErrors && !childWarnings) {
     return;

--- a/test/spec/LintingSpec.js
+++ b/test/spec/LintingSpec.js
@@ -419,6 +419,37 @@ describe('linting', function() {
         });
 
 
+        it('should show warning on root level', function(done) {
+
+          // given
+          const customConfig = {
+            ...bpmnlintrc,
+            'config': {
+              'rules': {
+                'start-event-required': 'warn'
+              }
+            }
+          };
+          const diagram = require('./missing-start-event.bpmn');
+
+          // when
+          modeler.get('linting').setLinterConfig(customConfig);
+
+          modeler.importXML(diagram).then(function() {
+
+            toggleLinting(modeler, function() {
+
+              // then
+              const processOverlays = el.querySelector('.djs-overlays[data-container-id="Process"]');
+              const warningIcon = processOverlays.querySelector('.bjsl-icon-warning');
+              expect(warningIcon).to.exist;
+
+              done();
+            });
+          });
+        });
+
+
         it('should show error overlay for a warning and an error', function(done) {
 
           // given
@@ -703,7 +734,6 @@ describe('linting', function() {
     });
 
   });
-
 });
 
 

--- a/test/spec/missing-start-event.bpmn
+++ b/test/spec/missing-start-event.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1sj0r4d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" name="Process" isExecutable="true">
+    <bpmn:task id="Activity_1tq2s4d">
+      <bpmn:outgoing>Flow_1k1gsjf</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_08k59xn">
+      <bpmn:incoming>Flow_1k1gsjf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1k1gsjf" sourceRef="Activity_1tq2s4d" targetRef="Event_08k59xn" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1k1gsjf_di" bpmnElement="Flow_1k1gsjf">
+        <di:waypoint x="260" y="117" />
+        <di:waypoint x="322" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1tq2s4d_di" bpmnElement="Activity_1tq2s4d">
+        <dc:Bounds x="160" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08k59xn_di" bpmnElement="Event_08k59xn">
+        <dc:Bounds x="322" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
While working with the linting plugin I've found a small mistake. Whenever you got child warnings on the root element, these are not displayed at all.

Before:

![Before](https://github.com/ssternal/bpmn-js-bpmnlint/raw/f82e7e3da5242fcadd04e78b7f00747652364cac/before.png)

After:

![After](https://github.com/ssternal/bpmn-js-bpmnlint/raw/f82e7e3da5242fcadd04e78b7f00747652364cac/after.png)