### PR TITLE
Always validate diagram (in background)

### DIFF
--- a/lib/Linting.js
+++ b/lib/Linting.js
@@ -75,9 +75,7 @@ export default function Linting(
     'linting.configChanged',
     'linting.toggle'
   ], LOW_PRIORITY, function(e) {
-    if (self.isActive()) {
-      self.update();
-    }
+    self.update();
   });
 
   eventBus.on('linting.toggle', function(event) {
@@ -269,7 +267,10 @@ Linting.prototype.update = function() {
     add = assign(add, update);
 
     self._clearOverlays();
-    self._createIssues(add);
+
+    if (self.isActive()) {
+      self._createIssues(add);
+    }
 
     self._issues = newIssues;
 
@@ -516,7 +517,7 @@ Linting.prototype._setButtonState = function(issues) {
   var label = this._translate(
     (errors || warnings)
       ? '{errors} Errors, {warnings} Warnings'
-      : 'Toggle Linting',
+      : 'No Issues',
     {
       errors: String(errors),
       warnings: String(warnings),
@@ -548,12 +549,6 @@ Linting.prototype._setButtonState = function(issues) {
 
 Linting.prototype._updateButton = function() {
 
-  if (!this.isActive()) {
-    this._setButtonState('inactive', 0, 0);
-
-    return;
-  }
-
   var errors = 0,
       warnings = 0,
       infos = 0;
@@ -582,7 +577,7 @@ Linting.prototype._createButton = function() {
   var self = this;
 
   this._button = domify(
-    '<button class="bjsl-button bjsl-button-inactive" title="' + this._translate('Toggle linting') + '"></button>'
+    '<button class="bjsl-button bjsl-button-inactive" title="' + this._translate('Toggle linting overlays') + '"></button>'
   );
 
   this._button.addEventListener('click', function() {

--- a/test/spec/LintingSpec.js
+++ b/test/spec/LintingSpec.js
@@ -702,7 +702,7 @@ describe('linting - i18n', function() {
     document.body.appendChild(el);
 
     const translations = {
-      'Toggle linting': 'Перемкнути перевірку',
+      'Toggle linting overlays': 'Перемкнути перевірку',
       'Process is missing end event': 'У процеса відсутня завершальна подія',
       '{errors} Errors, {warnings} Warnings': '{errors} помилок, {warnings} попередженнь'
     };


### PR DESCRIPTION
This changes the plug-in to eagerly validate a diagram. The button we previously used to toggle linting now acts as a toggle for showing annotations on the canvas. 

![capture kxTUAk_optimized](https://github.com/bpmn-io/bpmn-js-bpmnlint/assets/58601/24a8b15d-717a-43b7-b2db-e4e53f362d5b)

---

Closes https://github.com/bpmn-io/bpmn-js-bpmnlint/issues/20
